### PR TITLE
Browser not downloading the script because of CORS

### DIFF
--- a/instantpage/layouts/partials/jslibs/instantpage/script-src.html
+++ b/instantpage/layouts/partials/jslibs/instantpage/script-src.html
@@ -2,4 +2,4 @@
 {{/* The js.Build step is (currently) just there to create a IIFE module, see https://github.com/instantpage/instant.page/issues/81 */}}
 {{- $js := resources.Get "jslibs/instantpage/instantpage.js" | js.Build -}}
 {{- if $isProd }}{{ $js = $js | minify | fingerprint }}{{ end -}}
-<script src="{{ $js.RelPermalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+<script src="{{ $js.RelPermalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }} crossorigin="anonymous"></script>


### PR DESCRIPTION
The download of the script fails on Chrome and Brave with the message: 

```
Subresource Integrity: The resource 'https://d33wubrfki0l68.cloudfront.net/js/011d8daa2e942120a5f31f7b1f3c39a9a91534ed/jslibs/instantpage/instantpage.min.3ec179f8d7841c59b62d4881a9fdf625ebd683abd591eec843648d4099aa5197.js' has an integrity attribute, but the resource requires the request to be CORS enabled to check the integrity, and it is not. The resource has been blocked because the integrity cannot be enforced.
```
This error can be resolved by fixing CORS as per the example here: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#Examples