### PR TITLE
Fix typo, bump to Spruce v2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Hugo has great support for [JavaScript building](https://gohugo.io/hugo-pipes/js
 * The dependencies can be vendored (`hugo mod vendor`) to make your site truly standalone.
 * ...
 
-To use AlpineJS with Turbolinks you can just import the modules into your config and then add this to youer `head`
+To use AlpineJS with Turbolinks you can just import the modules into your config and then add this to your `head`
 
 ```
 {{ partialCached "jslibs/alpinejs/script-src.html" "-" }}

--- a/spruce/go.mod
+++ b/spruce/go.mod
@@ -2,4 +2,4 @@ module github.com/gohugoio/hugo-mod-jslibs/spruce
 
 go 1.15
 
-require github.com/ryangjchandler/spruce v2.6.4+incompatible // indirect
+require github.com/ryangjchandler/spruce v2.7.0+incompatible // indirect

--- a/spruce/go.sum
+++ b/spruce/go.sum
@@ -1,2 +1,2 @@
-github.com/ryangjchandler/spruce v2.6.4+incompatible h1:zsakUAAkr9NOkEYTzbjI3FL+1Fc3a6Q7BDzom+Bgl9g=
-github.com/ryangjchandler/spruce v2.6.4+incompatible/go.mod h1:pERscuhekU9NhSgrY8l7/0nLN1rBGBVnpvkMrVwGAZU=
+github.com/ryangjchandler/spruce v2.7.0+incompatible h1:rEfqFfhBWgo0yw0eNXL15R4R4Inxm3P6hH+CSRhtvww=
+github.com/ryangjchandler/spruce v2.7.0+incompatible/go.mod h1:pERscuhekU9NhSgrY8l7/0nLN1rBGBVnpvkMrVwGAZU=


### PR DESCRIPTION
Fixing typo in `README.md`
Bump to Spruce v2.7.0

Can you add a corresponding tag, please? Thanks.