### PR TITLE
Add instantclick library

### DIFF
--- a/instantclick/README.md
+++ b/instantclick/README.md
@@ -1,0 +1,21 @@
+## Installation
+
+First, add the module import to your site or theme component's configuration's module section:
+
+```toml
+[module]
+[[imports]]
+path = "github.com/gohugoio/hugo-mod-jslibs/instantclick"
+```
+
+Then add the script source before the end body tag:
+
+
+```html
+<body>
+...
+{{ partialCached "jslibs/instantclick/script-src.html" "-" }}
+</body>
+```
+
+See the [InstantClick](http://instantclick.io/) documentation for configuration.

--- a/instantclick/config.toml
+++ b/instantclick/config.toml
@@ -1,0 +1,9 @@
+[module]
+[[module.mounts]]
+source = "layouts"
+target = "layouts"
+[[module.imports]]
+path = "github.com/dieulot/instantclick"
+[[module.imports.mounts]]
+source = "instantclick.js"
+target = "assets/jslibs/instantclick/instantclick.js"

--- a/instantclick/go.mod
+++ b/instantclick/go.mod
@@ -1,0 +1,5 @@
+module github.com/gohugoio/hugo-mod-jslibs/instantclick
+
+go 1.15
+
+require github.com/dieulot/instantclick v3.1.0+incompatible // indirect

--- a/instantclick/go.sum
+++ b/instantclick/go.sum
@@ -1,0 +1,1 @@
+github.com/dieulot/instantclick v3.1.0+incompatible/go.mod h1:wsLe40wj03PAiS1Yv/apu920jdy3WAC9kvMk5T+4C20=

--- a/instantclick/layouts/partials/jslibs/instantclick/script-src.html
+++ b/instantclick/layouts/partials/jslibs/instantclick/script-src.html
@@ -1,0 +1,4 @@
+{{- $isProd := hugo.IsProduction -}}
+{{- $js := resources.Get "jslibs/instantclick/instantclick.js" | js.Build -}}
+{{- if $isProd }}{{ $js = $js | minify | fingerprint }}{{ end -}}
+<script src="{{ $js.RelPermalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>


### PR DESCRIPTION
[InstantClick](https://instantclick.io) is an older library by the same developer as instantpage. It also prefetches pages on mouseover, but only replaces body and title, which fits well with blog-like sites and gives a noticeable difference in speed compared with instantpage. Although a bit old, it is still well-used and stable.

I think it would be a great addition to this collection of jslibs.

My knowledge of Go, and especially its package system, is not great. So I couldn't find a way to test if this works. I've based most of it on the instantclick part of this repo.

Thank you in advance for considering this addition.